### PR TITLE
Fix definition of begin keyword

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -19,7 +19,7 @@ LogSummary	KEYWORD1
 #######################################
 # Instances (KEYWORD2)
 #######################################
-void begin	KEYWORD2
+begin	KEYWORD2
 quickReads	KEYWORD2
 setQuickReads	KEYWORD2
 updateThermoReading	KEYWORD2


### PR DESCRIPTION
The type was left on in the keyword definition, which caused it to not be recognized by the Arduino IDE.